### PR TITLE
Feat: Implemented prompt limit in a single chat session

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cSpell.ignoreWords": [
+        "privgpt"
+    ],
+    "cSpell.words": [
+        "dotenv"
+    ]
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,6 @@ MONGODB_URL="YOUR_MONGODB_URL"
 
 # Gemini API key
 GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
+
+# Maximum messages per session
+MAX_MESSAGES_PER_SESSION=5

--- a/server/config.py
+++ b/server/config.py
@@ -5,11 +5,8 @@ load_dotenv()
 class Config:
     CORS_HEADERS = "Content-Type"
     #here the second value shows the default value if the environment variable is not set
-    MONGO_URI = os.getenv("MONGODB_URL", "mongodb://localhost:27017/")
+    MONGO_URI = os.getenv("MONGODB_URL", "mongodb://localhost:27017/privgpt")
     ALLOWED_EXTENSIONS = {"pdf", "png", "jpg", "jpeg", "gif"}
     GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "your_gemini_api_key")
     SECRET_KEY = os.getenv("SECRET_KEY", "dev_secret_key")
-
-
-
-
+    MAX_MESSAGES_PER_SESSION = int(os.getenv("MAX_MESSAGES_PER_SESSION", 10))


### PR DESCRIPTION
# Fixes Issue
Closes #43

# Description
This PR implements a configurable limit on the number of user messages allowed per chat session to manage resource usage and API costs effectively.

**Key Changes:**
* **Backend:** Implemented `has_reached_message_limit` check in both standard `/chat` and streaming `/chat/stream` endpoints. Returns a `403` error when the limit is hit.
* **Frontend:** Added UI logic to disable the input box and show a red warning banner when the `limit_reached` flag is received.

# Type of change
- [x] 💡 New feature

# Checklist
- [x] I am a ECWoC contributor
- [x] My code follows the project’s style guidelines

# Packages Added (if any)


# Screenshots / Video
<img width="512" height="288" alt="image" src="https://github.com/user-attachments/assets/ea82c86b-8d69-4627-b640-ccbbd28c4fa9" />

Testing video drive link (view access provided) - https://drive.google.com/file/d/1qZ__ZfaEJpGGjIN9L3okDY9SyfzntU-l/view?usp=sharing