### PR TITLE
Added promt limit reached popup feature in older chats

### DIFF
--- a/client/app/chat/page.tsx
+++ b/client/app/chat/page.tsx
@@ -2196,6 +2196,10 @@ export default function ChatPage() {
 
       const data = await response.json();
 
+      if (data.limit_reached) {
+        setIsLimitReached(true);
+      }
+
       const formattedMessages: Message[] = data.messages.map(
         (msg: any, index: number) => {
           const normalizedRole: "user" | "assistant" =

--- a/server/api/routes/chat_routes.py
+++ b/server/api/routes/chat_routes.py
@@ -676,10 +676,13 @@ def get_session_messages(session_id):
         for msg in session.get("messages", []):
             if "timestamp" in msg:
                 msg["timestamp"] = msg["timestamp"].isoformat()
+        
+        limit_reached = has_reached_message_limit(session_id)
 
         return jsonify({
             "session_id": str(session["_id"]),
-            "messages": session["messages"]
+            "messages": session["messages"],
+            "limit_reached": limit_reached
         })
 
     except Exception as e:


### PR DESCRIPTION
# Fixes Issue
<!-- Example: Closes #32 -->
Fixes #159 

# Description
This PR improves the user experience by immediately disabling the chat input and displaying the "Limit Reached" warning when a user loads a chat session that has already exceeded the message limit. Previously, the warning only appeared after the user attempted to send a new message.

# Type of change
- [ ] 💡 Feature enhancement

# Checklist
<!-- Please delete the options that are not relevant to you. -->
- [ ] I am a ECWoC contributor
- [ ] My code follows the project’s style guidelines
- [ ] I have added comments in areas that may be hard to understand
- [ ] I have NOT included `package.json` or `package-lock.json` in this PR

# Packages Added (if any)

# Screenshot
<img width="1366" height="768" alt="Screenshot 2026-01-06 082155" src="https://github.com/user-attachments/assets/017bc0d1-8036-4042-89c7-bacf7aa9d1ff" />
