### PR TITLE
fix: add 10-digit phone number validation

### DIFF
--- a/client/components/auth/SignUpForm.tsx
+++ b/client/components/auth/SignUpForm.tsx
@@ -45,7 +45,12 @@ const formSchema = z
     username: z.string().optional(),
     gender: z.enum(["male", "female", "other"]).optional().or(z.literal("")),
     dob: z.string().optional(),
-    phone: z.string().optional(),
+    phone: z
+      .string()
+      .regex(/^[1-9]\d{9}$/, {
+        message: "Phone number must be a valid 10-digit number",
+      })
+      .optional().or(z.literal("")),
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords don't match.",
@@ -100,7 +105,7 @@ export function SignUpForm() {
   }
 
   return (
-    <Card className="mx-auto max-w-sm w-full">
+    <Card className="w-full max-w-sm mx-auto">
       <CardHeader>
         <CardTitle className="text-2xl">Sign Up</CardTitle>
         <CardDescription>
@@ -152,7 +157,7 @@ export function SignUpForm() {
 
             <hr className="my-2" />
 
-            <p className="text-sm text-muted-foreground -mt-2">
+            <p className="-mt-2 text-sm text-muted-foreground">
               These fields are optional. You can update them later.
             </p>
 
@@ -228,7 +233,7 @@ export function SignUpForm() {
             </Button>
           </form>
         </Form>
-        <div className="mt-4 text-center text-sm">
+        <div className="mt-4 text-sm text-center">
           Already have an account?{" "}
           <Link href="/sign-in" className="underline">
             Sign in


### PR DESCRIPTION
# Fixes Issue
Fixes #174

# Description
This PR fixes the phone number input on the signup form by:
- Accepting only 10-digit numbers.
- Rejecting letters, symbols, or numbers of invalid length.
- Keeping the field optional.
- Validating onChange so errors disappear immediately when a valid number is entered.

Impact:
- Prevents invalid data submission.
- Improves form UX.
- Maintains simple validation.

# Type of change
- [x] 🐛 Bug fix

# Checklist
- [x] I am a ECWoc'26 contributor
- [x] My code follows the project’s style guidelines
- [x] I have added comments in areas that may be hard to understand
- [x] I have NOT included `package.json` or `package-lock.json` in this PR

# Packages Added (if any)
None

# Screenshots
<img width="400" height="300" alt="Screenshot 2026-01-07 174543" src="https://github.com/user-attachments/assets/aafc52ec-f66c-4693-b442-19f83fa8b530" />
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/cb963a11-f69d-4ab2-9373-f4d712ae7d42" />

