### PR TITLE
feat: add footer links for GitHub, Discord, and Email

### DIFF
--- a/client/components/ui/footer.tsx
+++ b/client/components/ui/footer.tsx
@@ -1,18 +1,21 @@
 "use client";
 
-import { Zap, Star, Github, Twitter, Mail, Menu } from "lucide-react";
+import { Github, Mail } from "lucide-react";
+import { AiOutlineDiscord } from "react-icons/ai";
 import Link from "next/link";
 import Image from "next/image";
 import { useTheme } from "@/components/theme-provider";
 
-export default function footer() {
+export default function Footer() {
   const { darkMode } = useTheme();
+
   return (
     <footer className="border-t py-12 bg-background px-4">
       <div className="container mx-auto">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-8">
+          
+          {/* Logo + Description */}
           <div className="md:col-span-4">
-
             <Link href="/" className="flex items-center">
               <Image
                 src={darkMode ? "/logos/logo-dark.svg" : "/logos/logo-light.svg"}
@@ -102,22 +105,35 @@ export default function footer() {
           {/* Connect */}
           <div className="md:col-span-2">
             <h3 className="font-semibold mb-4">Connect</h3>
-            <div className="flex space-x-5">
-              <Link
-                href="#"
-                className="text-muted-foreground hover:text-foreground"
+            <div className="flex space-x-5 text-muted-foreground">
+              
+              {/* GitHub */}
+              <a
+                href="https://github.com/Rucha-Ambaliya/PrivGPT-Studio"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub"
+                className="hover:text-foreground transition"
               >
                 <Github className="w-6 h-6" />
-              </Link>
-              <Link
-                href="#"
-                className="text-muted-foreground hover:text-foreground"
+              </a>
+
+              {/* Discord (outline icon as requested) */}
+              <a
+                href="https://discord.gg/J9z5T52rkZ"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Discord"
+                className="hover:text-foreground transition"
               >
-                <Twitter className="w-6 h-6" />
-              </Link>
+                <AiOutlineDiscord className="w-7 h-8 -m-1" />
+              </a>
+
+              {/* Email */}
               <Link
-                href="#"
-                className="text-muted-foreground hover:text-foreground"
+                href="/"
+                aria-label="Email"
+                className="hover:text-foreground transition"
               >
                 <Mail className="w-6 h-6" />
               </Link>


### PR DESCRIPTION
This PR reintroduces the footer links for GitHub, Discord, and Email.

The earlier PR (#160) was reverted only because a label was missed at merge time.
There are no functional changes compared to the previously approved implementation.

Please add the required label (ECWoC 26) and merge. Thanks! 🙌
