### PR TITLE
fix: remove duplicate layout wrapper from legal pages

### DIFF
--- a/client/app/(main)/privacy-policy/page.tsx
+++ b/client/app/(main)/privacy-policy/page.tsx
@@ -17,7 +17,6 @@ import {
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
 import Head from "next/head";
-import Layout from "@/components/layout";
 
 export default function PrivacyPolicyPage() {
   return (
@@ -79,7 +78,7 @@ export default function PrivacyPolicyPage() {
         />
       </Head>
       
-      <Layout>
+
 
       {/* Quick Overview */}
       <section className="py-8 px-4">
@@ -575,7 +574,7 @@ export default function PrivacyPolicyPage() {
         </div>
       </section>
 
-      </Layout>
+
     </div>
   );
 }

--- a/client/app/(main)/terms/page.tsx
+++ b/client/app/(main)/terms/page.tsx
@@ -7,7 +7,7 @@ import { Zap, FileText, Clock, Mail } from "lucide-react";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
 import Head from "next/head";
-import Layout from "@/components/layout";
+
 
 export default function TermsOfService() {
   return (
@@ -69,7 +69,7 @@ export default function TermsOfService() {
         <link rel="canonical" href="https://privgpt-studio.vercel.app/terms" />
       </Head>
       
-      <Layout>
+    
 
       {/* Hero Section */}
       <section className="py-12 px-4 bg-muted/50">
@@ -231,7 +231,7 @@ export default function TermsOfService() {
         </div>
       </section>
 
-      </Layout>
+
     </div>
   );
 }


### PR DESCRIPTION
<!--
Title format - fix:  prevent navbar and footer from rendering twice on legal pages


# Fixes Issue
Fixes #210

# Description
This PR fixes an issue where the navbar and footer were rendering twice
on the Privacy Policy and Terms of Service pages.

The issue occurred because these pages were wrapped with a local Layout
component, while Header and Footer are already rendered globally via
ClientLayout in app/layout.tsx.

This fix removes the redundant Layout wrapper and relies on the shared
App Router layout, preventing duplicate rendering.


# Type of change
<!-- Please delete the options that are not relevant to you. -->
- [ x] 🐛 Bug fix
- [ ] 💡 New feature
- [ ] 📖 Documentation update
- [ ] 💭 Other (please specify):

# Checklist
<!-- Please delete the options that are not relevant to you. -->
- [x ] I am a ECWoc'26 contributor
- [x ] My code follows the project’s style guidelines
- [x ] I have added comments in areas that may be hard to understand
- [ x] I have NOT included `package.json` or `package-lock.json` in this PR

# Packages Added (if any)
None

# Screenshots / Video (if applicable)
NA
