### PR TITLE
Fix: Pricing Page UI Inconsistencies (Card Alignment, Padding, Hover Effects & Trust Strip) 

### DIFF
--- a/client/app/(main)/pricing/page.tsx
+++ b/client/app/(main)/pricing/page.tsx
@@ -74,55 +74,94 @@ export default function PricingPage() {
             Choose Your Plan
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Unlock the full potential of PrivGPT Studio. Switch between cloud and local AI models seamlessly with a plan that fits you.
+            Unlock the full potential of PrivGPT Studio. Switch between cloud and
+            local AI models seamlessly with a plan that fits you.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
-          {plans.map((plan, index) => (
-            <Card 
-              key={plan.name} 
+        {/* Extra top padding so the badge on the popular card has room */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-center pt-6">
+          {plans.map((plan) => (
+            <Card
+              key={plan.name}
               className={`
-                relative flex flex-col transition-all duration-300 hover:shadow-xl hover:-translate-y-2
-                ${plan.popular 
-                  ? 'border-primary shadow-md md:-mt-8 md:mb-8 z-10 scale-105' 
-                  : 'hover:border-primary/50'}
+                relative flex flex-col transition-all duration-300
+                ${plan.popular
+                  ? "border-2 border-primary shadow-xl ring-2 ring-primary/30 md:-mt-6 md:mb-6 z-10 hover:shadow-2xl hover:-translate-y-2"
+                  : "hover:shadow-lg hover:-translate-y-1 hover:border-primary/50"
+                }
               `}
             >
               {plan.popular && (
                 <div className="absolute -top-4 left-0 right-0 flex justify-center">
-                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-3 py-1">
-                    Most Popular
+                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-4 py-1 text-sm font-semibold shadow-md">
+                    ⭐ Most Popular
                   </Badge>
                 </div>
               )}
-              <CardHeader>
-                <CardTitle className="text-2xl">{plan.name}</CardTitle>
+
+              <CardHeader className={plan.popular ? "p-7 pt-9" : "p-6"}>
+                <CardTitle className={plan.popular ? "text-3xl font-bold" : "text-2xl"}>
+                  {plan.name}
+                </CardTitle>
                 <CardDescription>{plan.description}</CardDescription>
               </CardHeader>
-              <CardContent className="flex-grow">
+
+              <CardContent className={`flex-grow ${plan.popular ? "p-7" : "p-6"}`}>
                 <div className="mb-6 flex items-baseline">
-                  <span className="text-4xl font-bold">{plan.price}</span>
-                  {plan.period && <span className="text-muted-foreground ml-1">{plan.period}</span>}
+                  <span className={plan.popular ? "text-5xl font-bold" : "text-4xl font-bold"}>
+                    {plan.price}
+                  </span>
+                  {plan.period && (
+                    <span className="text-muted-foreground ml-1">{plan.period}</span>
+                  )}
                 </div>
                 <ul className="space-y-3">
                   {plan.features.map((feature) => (
                     <li key={feature} className="flex items-center gap-2">
-                      <div className="bg-primary/10 rounded-full p-1">
-                        <Check className="w-3 h-3 text-primary" />
+                      <div className="bg-primary/10 rounded-full p-1 flex-shrink-0">
+                        <Check className="w-3 h-3 text-primary flex-shrink-0" />
                       </div>
                       <span className="text-sm text-muted-foreground">{feature}</span>
                     </li>
                   ))}
                 </ul>
               </CardContent>
-              <CardFooter className="mt-auto">
-                <Button className="w-full" variant={plan.variant} size="lg">
+
+              <CardFooter className={`mt-auto ${plan.popular ? "p-7 pt-4" : "p-6"}`}>
+                <Button
+                  className="w-full"
+                  variant={plan.variant}
+                  size="lg"
+                >
                   {plan.cta}
                 </Button>
               </CardFooter>
             </Card>
           ))}
+        </div>
+
+        {/* Trust strip */}
+        <div className="mt-16 flex flex-wrap justify-center gap-8 text-sm text-muted-foreground">
+          {["No credit card required", "Cancel anytime", "Instant activation"].map((item) => (
+            <div
+              key={item}
+              className="flex items-center gap-2 hover:text-primary transition-all duration-200 hover:-translate-y-1"
+            >
+              <Check className="w-4 h-4 text-primary flex-shrink-0" />
+              <span>{item}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Bottom CTA */}
+        <div className="mt-12 text-center">
+          <p className="text-muted-foreground text-sm">
+            Need a custom plan?{" "}
+            <a href="/contact" className="text-primary underline underline-offset-4 hover:text-primary/80">
+              Contact us
+            </a>
+          </p>
         </div>
       </div>
     </div>

--- a/client/app/(main)/pricing/page.tsx
+++ b/client/app/(main)/pricing/page.tsx
@@ -80,60 +80,57 @@ export default function PricingPage() {
         </div>
 
         {/* Extra top padding so the badge on the popular card has room */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-stretch pt-12 max-w-5xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch pt-10">
           {plans.map((plan) => (
-            <div key={plan.name} className={`relative flex flex-col ${plan.popular ? "" : "md:py-8"}`}>
-              {plan.popular && (
-                <div className="absolute inset-0 bg-gradient-to-r from-primary/20 to-blue-500/20 rounded-[2rem] blur-xl -z-10 transform scale-95" />
-              )}
+            <div key={plan.name} className={`h-full ${plan.popular ? "" : "md:py-6"}`}>
               <Card
                 className={`
-                  relative flex flex-col flex-1 transition-all duration-500 rounded-2xl
+                  relative flex flex-col h-full transition-all duration-300
                   ${plan.popular
-                    ? "border-2 border-primary shadow-2xl shadow-primary/20 z-10 hover:shadow-primary/40 hover:-translate-y-2 bg-card"
-                    : "border border-border/50 hover:shadow-xl hover:-translate-y-1 hover:border-primary/50 bg-card/50 backdrop-blur-sm"
+                    ? "border-2 border-primary shadow-xl ring-2 ring-primary/30 z-10 hover:shadow-2xl hover:-translate-y-2"
+                    : "hover:shadow-lg hover:-translate-y-1 hover:border-primary/50"
                   }
                 `}
               >
                 {plan.popular && (
-                  <div className="absolute -top-5 left-0 right-0 flex justify-center z-20">
-                    <Badge className="bg-gradient-to-r from-primary to-blue-600 text-primary-foreground border-none px-5 py-1.5 text-sm font-bold shadow-lg flex items-center gap-1.5 rounded-full uppercase tracking-wider">
-                      <Star className="w-4 h-4 fill-current" /> Most Popular
+                  <div className="absolute -top-4 left-0 right-0 flex justify-center">
+                    <Badge className="bg-primary text-primary-foreground hover:bg-primary px-4 py-1 text-sm font-semibold shadow-md flex items-center gap-1">
+                      <Star className="w-3 h-3 fill-current" /> Most Popular
                     </Badge>
                   </div>
                 )}
 
-                <CardHeader className={plan.popular ? "p-8 pb-4" : "p-6 pb-4"}>
-                  <CardTitle className={plan.popular ? "text-3xl font-extrabold text-foreground" : "text-2xl font-bold"}>
+                <CardHeader className={plan.popular ? "p-7 pt-9" : "p-6"}>
+                  <CardTitle className={plan.popular ? "text-3xl font-bold" : "text-2xl"}>
                     {plan.name}
                   </CardTitle>
-                  <CardDescription className="font-medium text-muted-foreground/80 mt-2">{plan.description}</CardDescription>
+                  <CardDescription>{plan.description}</CardDescription>
                 </CardHeader>
 
-                <CardContent className={`flex-1 ${plan.popular ? "p-8 pt-2" : "p-6 pt-2"}`}>
-                  <div className="mb-8 flex items-baseline">
-                    <span className={plan.popular ? "text-6xl font-extrabold" : "text-5xl font-bold"}>
+                <CardContent className={`flex-grow ${plan.popular ? "p-7" : "p-6"}`}>
+                  <div className="mb-6 flex items-baseline">
+                    <span className={plan.popular ? "text-5xl font-bold" : "text-4xl font-bold"}>
                       {plan.price}
                     </span>
                     {plan.period && (
-                      <span className="text-lg text-muted-foreground ml-2 font-medium">{plan.period}</span>
+                      <span className="text-muted-foreground ml-1">{plan.period}</span>
                     )}
                   </div>
-                  <ul className="space-y-4">
+                  <ul className="space-y-3">
                     {plan.features.map((feature) => (
-                      <li key={feature} className="flex items-start gap-3">
-                        <div className={`rounded-full p-1 mt-0.5 flex-shrink-0 ${plan.popular ? "bg-primary text-primary-foreground shadow-sm" : "bg-primary/10 text-primary"}`}>
-                          <Check className="w-3.5 h-3.5 flex-shrink-0" strokeWidth={3} />
+                      <li key={feature} className="flex items-center gap-2">
+                        <div className="bg-primary/10 rounded-full p-1 flex-shrink-0">
+                          <Check className="w-3 h-3 text-primary flex-shrink-0" />
                         </div>
-                        <span className="text-sm font-medium text-foreground/80">{feature}</span>
+                        <span className="text-sm text-muted-foreground">{feature}</span>
                       </li>
                     ))}
                   </ul>
                 </CardContent>
 
-                <CardFooter className={`mt-auto ${plan.popular ? "p-8 pt-4" : "p-6 pt-4"}`}>
+                <CardFooter className={`mt-auto ${plan.popular ? "p-7 pt-4" : "p-6"}`}>
                   <Button
-                    className={`w-full rounded-xl font-bold text-md h-12 transition-all duration-300 ${plan.popular ? "shadow-lg shadow-primary/30 hover:shadow-xl hover:shadow-primary/40" : ""}`}
+                    className="w-full"
                     variant={plan.variant}
                     size="lg"
                   >

--- a/client/app/(main)/pricing/page.tsx
+++ b/client/app/(main)/pricing/page.tsx
@@ -80,64 +80,68 @@ export default function PricingPage() {
         </div>
 
         {/* Extra top padding so the badge on the popular card has room */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-center pt-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-stretch pt-12 max-w-5xl mx-auto">
           {plans.map((plan) => (
-            <Card
-              key={plan.name}
-              className={`
-                relative flex flex-col transition-all duration-300
-                ${plan.popular
-                  ? "border-2 border-primary shadow-xl ring-2 ring-primary/30 md:-mt-6 md:mb-6 z-10 hover:shadow-2xl hover:-translate-y-2"
-                  : "hover:shadow-lg hover:-translate-y-1 hover:border-primary/50"
-                }
-              `}
-            >
+            <div key={plan.name} className={`relative flex flex-col ${plan.popular ? "" : "md:py-8"}`}>
               {plan.popular && (
-                <div className="absolute -top-4 left-0 right-0 flex justify-center">
-                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-4 py-1 text-sm font-semibold shadow-md flex items-center gap-1">
-                    <Star className="w-3 h-3 fill-current" /> Most Popular
-                  </Badge>
-                </div>
+                <div className="absolute inset-0 bg-gradient-to-r from-primary/20 to-blue-500/20 rounded-[2rem] blur-xl -z-10 transform scale-95" />
               )}
+              <Card
+                className={`
+                  relative flex flex-col flex-1 transition-all duration-500 rounded-2xl
+                  ${plan.popular
+                    ? "border-2 border-primary shadow-2xl shadow-primary/20 z-10 hover:shadow-primary/40 hover:-translate-y-2 bg-card"
+                    : "border border-border/50 hover:shadow-xl hover:-translate-y-1 hover:border-primary/50 bg-card/50 backdrop-blur-sm"
+                  }
+                `}
+              >
+                {plan.popular && (
+                  <div className="absolute -top-5 left-0 right-0 flex justify-center z-20">
+                    <Badge className="bg-gradient-to-r from-primary to-blue-600 text-primary-foreground border-none px-5 py-1.5 text-sm font-bold shadow-lg flex items-center gap-1.5 rounded-full uppercase tracking-wider">
+                      <Star className="w-4 h-4 fill-current" /> Most Popular
+                    </Badge>
+                  </div>
+                )}
 
-              <CardHeader className={plan.popular ? "p-7 pt-9" : "p-6"}>
-                <CardTitle className={plan.popular ? "text-3xl font-bold" : "text-2xl"}>
-                  {plan.name}
-                </CardTitle>
-                <CardDescription>{plan.description}</CardDescription>
-              </CardHeader>
+                <CardHeader className={plan.popular ? "p-8 pb-4" : "p-6 pb-4"}>
+                  <CardTitle className={plan.popular ? "text-3xl font-extrabold text-foreground" : "text-2xl font-bold"}>
+                    {plan.name}
+                  </CardTitle>
+                  <CardDescription className="font-medium text-muted-foreground/80 mt-2">{plan.description}</CardDescription>
+                </CardHeader>
 
-              <CardContent className={`flex-grow ${plan.popular ? "p-7" : "p-6"}`}>
-                <div className="mb-6 flex items-baseline">
-                  <span className={plan.popular ? "text-5xl font-bold" : "text-4xl font-bold"}>
-                    {plan.price}
-                  </span>
-                  {plan.period && (
-                    <span className="text-muted-foreground ml-1">{plan.period}</span>
-                  )}
-                </div>
-                <ul className="space-y-3">
-                  {plan.features.map((feature) => (
-                    <li key={feature} className="flex items-center gap-2">
-                      <div className="bg-primary/10 rounded-full p-1 flex-shrink-0">
-                        <Check className="w-3 h-3 text-primary flex-shrink-0" />
-                      </div>
-                      <span className="text-sm text-muted-foreground">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
+                <CardContent className={`flex-1 ${plan.popular ? "p-8 pt-2" : "p-6 pt-2"}`}>
+                  <div className="mb-8 flex items-baseline">
+                    <span className={plan.popular ? "text-6xl font-extrabold" : "text-5xl font-bold"}>
+                      {plan.price}
+                    </span>
+                    {plan.period && (
+                      <span className="text-lg text-muted-foreground ml-2 font-medium">{plan.period}</span>
+                    )}
+                  </div>
+                  <ul className="space-y-4">
+                    {plan.features.map((feature) => (
+                      <li key={feature} className="flex items-start gap-3">
+                        <div className={`rounded-full p-1 mt-0.5 flex-shrink-0 ${plan.popular ? "bg-primary text-primary-foreground shadow-sm" : "bg-primary/10 text-primary"}`}>
+                          <Check className="w-3.5 h-3.5 flex-shrink-0" strokeWidth={3} />
+                        </div>
+                        <span className="text-sm font-medium text-foreground/80">{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
 
-              <CardFooter className={`mt-auto ${plan.popular ? "p-7 pt-4" : "p-6"}`}>
-                <Button
-                  className="w-full"
-                  variant={plan.variant}
-                  size="lg"
-                >
-                  {plan.cta}
-                </Button>
-              </CardFooter>
-            </Card>
+                <CardFooter className={`mt-auto ${plan.popular ? "p-8 pt-4" : "p-6 pt-4"}`}>
+                  <Button
+                    className={`w-full rounded-xl font-bold text-md h-12 transition-all duration-300 ${plan.popular ? "shadow-lg shadow-primary/30 hover:shadow-xl hover:shadow-primary/40" : ""}`}
+                    variant={plan.variant}
+                    size="lg"
+                  >
+                    {plan.cta}
+                  </Button>
+                </CardFooter>
+              </Card>
+            </div>
           ))}
         </div>
 

--- a/client/app/(main)/pricing/page.tsx
+++ b/client/app/(main)/pricing/page.tsx
@@ -9,7 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Check } from "lucide-react";
+import { Check, Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 
 export default function PricingPage() {
@@ -94,8 +94,8 @@ export default function PricingPage() {
             >
               {plan.popular && (
                 <div className="absolute -top-4 left-0 right-0 flex justify-center">
-                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-4 py-1 text-sm font-semibold shadow-md">
-                    ⭐ Most Popular
+                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-4 py-1 text-sm font-semibold shadow-md flex items-center gap-1">
+                    <Star className="w-3 h-3 fill-current" /> Most Popular
                   </Badge>
                 </div>
               )}

--- a/client/app/(main)/pricing/page.tsx
+++ b/client/app/(main)/pricing/page.tsx
@@ -167,3 +167,4 @@ export default function PricingPage() {
     </div>
   );
 }
+// Trigger PR review build


### PR DESCRIPTION
…ominent

<!--
Title format - <type>: <brief description>
fix: pricing page UI inconsistencies and Most Popular card prominence

| Type  | Use when                          |
|-------|-----------------------------------|
| feat  | Adding a new feature              |
| fix   | Fixing a bug                      |
| docs  | Documentation changes only        |
| test  | Adding or updating tests          |
| chore | Maintenance, CI, config, tooling  |

Examples:
feat: add chat export to PDF
fix: crash when uploading large files
docs: update setup instructions
-->

<!-- Thank you for taking the time to contribute! 🙌 -->

# Fixes Issue
<!-- Example: Closes #32 -->
Fixes #265 

# Description
<!-- Briefly describe the changes you’ve made. -->
## Description
The Pricing page had multiple UI inconsistencies:
- **Misaligned cards** — Fixed card alignment so all 3 cards sit in the same row.
- **Inconsistent card padding** — Standardized to `p-6`/`p-7` on CardHeader, CardContent, and CardFooter.
- **Inconsistent hover effects** — Applied uniform `hover:shadow-lg hover:-translate-y-1 transition-all duration-300` to all cards.
- **Check icon alignment** — Added `flex-shrink-0` to all check icon wrappers.
- **Missing trust indicators and CTA** — Added trust strip (No CC, Cancel anytime, Instant activation) and a bottom CTA section.
- **Most Popular card prominence** — Made the Basic card visually larger with `border-2`, `ring-2`, bigger padding and fonts to attract users.

# Type of change
<!-- Please delete the options that are not relevant to you. -->
- [x] 🐛 Bug fix


# Checklist
<!-- Please delete the options that are not relevant to you. -->
- [x] I am a ECWoc'26 contributor
- [x] My code follows the project’s style guidelines
- [x] I have NOT included `package.json` or `package-lock.json` in this PR

# Packages Added (if any)
<!-- List any new dependencies added. If none, leave blank. -->

# Screenshots / Video (if applicable)
<!-- Include UI screenshots or GIFs to demonstrate the changes. -->
<img width="1919" height="909" alt="image" src="https://github.com/user-attachments/assets/1fb6240f-feca-4099-8f29-c935a4de42e1" />
